### PR TITLE
Fix find_colliding_pairs_with_iter

### DIFF
--- a/broccoli/src/queries/intersect_with.rs
+++ b/broccoli/src/queries/intersect_with.rs
@@ -37,7 +37,7 @@ impl<'a, T: Aabb> Tree<'a, T> {
         //The two trees could be recursed at the same time to break up the problem.
 
         for i in other {
-            self.find_all_in_rect(i, |r, a| func(a, r))
+            self.find_all_intersect_rect(i, |r, a| func(a, r))
         }
     }
 }


### PR DESCRIPTION
It seems like a call to find_all_intersect_rect should be there, at least according to the comment above.